### PR TITLE
Fix missing home directory

### DIFF
--- a/create_github_user_ssh_key.sh
+++ b/create_github_user_ssh_key.sh
@@ -8,7 +8,7 @@ if [[ ! -z "$GITHUB_USER_SSH_KEY" ]] ; then
   mkdir -p "$ATLANTIS_HOME/.ssh"
 
   if [ ! -f "$ATLANTIS_HOME/.ssh/id_rsa" ]; then
-    echo "${GITHUB_USER_SSH_KEY}" | base64 -d | gunzip > "${HOME}/.ssh/id_rsa"
+    echo "${GITHUB_USER_SSH_KEY}" | base64 -d | gunzip > "${ATLANTIS_HOME}/.ssh/id_rsa"
     chmod 600 "$ATLANTIS_HOME/.ssh/id_rsa"
     ssh-keyscan github.com >> "$ATLANTIS_HOME/.ssh/known_hosts"
     chown atlantis:atlantis "$ATLANTIS_HOME/.ssh/id_rsa"


### PR DESCRIPTION
Fix issue below:

```bash
/usr/local/bin/create_github_user_ssh_key.sh: line 11: can't create /root/.ssh/id_rsa: nonexistent directory
```