### PR TITLE
OPS-0 Making sure we use terraform version 0.12.29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ RUN apk add unzip make curl
 
 # TODO: verify GPG
 ARG TERRAGRUNT_VERSION='0.21.7'
+ARG DEFAULT_TERRAFORM_VERSION=0.12.29
+
+RUN  \
+  rm -rf /usr/local/bin/terraform \
+  && ln -s /usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform /usr/local/bin/terraform
 
 RUN \
 # Download the binary and checksum


### PR DESCRIPTION
With this change we ensure we are going to be using terraform 0.12.29 untill our code its adjusted to terraform 0.13