### PR TITLE
OPS-3673 Remove fixed patch version for terragrunt

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: False
       matrix:
         TF_VERSION: [0.12,0.13,latest]
-        TG_VERSION: [0.21,0.21,0.22,0.23,latest]
+        TG_VERSION: [0.21,0.22,0.23,latest]
     steps:
       # ------------------------------------------------------------
       # Checkout repository

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -21,8 +21,15 @@ jobs:
     strategy:
       fail-fast: False
       matrix:
-        TF_VERSION: [0.12,0.13,latest]
-        TG_VERSION: [0.21,0.22,0.23,latest]
+        TF_VERSION:
+          - 0.12
+          - 0.13
+          - latest
+        TG_VERSION:
+          - 0.21
+          - 0.22
+          - 0.23
+          - latest
     steps:
       # ------------------------------------------------------------
       # Checkout repository

--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -22,10 +22,7 @@ jobs:
       fail-fast: False
       matrix:
         TF_VERSION: [0.12,0.13,latest]
-        TG_VERSION: [0.21,0.21.7,0.22,latest]
-        exclude:
-          - { TF_VERSION: latest, TG_VERSION: 0.21.7 }
-          - { TF_VERSION: 0.13,   TG_VERSION: 0.21.7 }
+        TG_VERSION: [0.21,0.21,0.22,0.23,latest]
     steps:
       # ------------------------------------------------------------
       # Checkout repository

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,6 @@ RUN set -eux \
                   | sort -u \
                   | sort -V \
                   | tail -1 )"; \
-    elif [ "${TERRAGRUNT_VERSION}" = "0.21.7" ]; then \
-        DEFAULT_TERRAGRUNT_VERSION=$TERRAGRUNT_VERSION; \
     else \
         git clone https://github.com/gruntwork-io/terragrunt /terragrunt; \
         cd /terragrunt; \


### PR DESCRIPTION
Remove fixed version 0.21.7 from the matrix and remove the exclude option