### PR TITLE
OPS-0 Add Folder and change ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM runatlantis/atlantis:latest
 
 RUN apk add unzip make curl
-
+RUN chown atlantis:atlantis /home/atlantis/ -R
 # TODO: verify GPG
 ARG TERRAGRUNT_VERSION=0.21
 ENV DEFAULT_TERRAGRUNT_VERSION=$TERRAGRUNT_VERSION
@@ -59,3 +59,5 @@ RUN mv /usr/local/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint-orig
 # the new docker-entrypoint.sh will do some work and then call the original entry point
 ADD docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ADD create_github_user_ssh_key.sh /usr/local/bin/create_github_user_ssh_key.sh
+
+RUN chown atlantis:atlantis /home/atlantis/ -R

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,5 @@ RUN mv /usr/local/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint-orig
 # the new docker-entrypoint.sh will do some work and then call the original entry point
 ADD docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ADD create_github_user_ssh_key.sh /usr/local/bin/create_github_user_ssh_key.sh
-
-RUN mkdir /mnt/efs \
-    && chown atlantis:atlantis /mnt/efs/ -R 
+# Creates directory to mount EFS
+RUN mkdir /mnt/efs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM runatlantis/atlantis:latest
 
 RUN apk add unzip make curl
-RUN chown atlantis:atlantis /home/atlantis/ -R
+
 # TODO: verify GPG
 ARG TERRAGRUNT_VERSION=0.21
 ENV DEFAULT_TERRAGRUNT_VERSION=$TERRAGRUNT_VERSION
@@ -61,3 +61,7 @@ ADD docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ADD create_github_user_ssh_key.sh /usr/local/bin/create_github_user_ssh_key.sh
 
 RUN chown atlantis:atlantis /home/atlantis/ -R
+RUN ls -la /
+RUN ls -la /mnt
+RUN whoami
+RUN mount

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,8 +60,5 @@ RUN mv /usr/local/bin/docker-entrypoint.sh /usr/local/bin/docker-entrypoint-orig
 ADD docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ADD create_github_user_ssh_key.sh /usr/local/bin/create_github_user_ssh_key.sh
 
-RUN chown atlantis:atlantis /home/atlantis/ -R
-RUN ls -la /
-RUN ls -la /mnt
-RUN whoami
-RUN mount
+RUN mkdir /mnt/efs \
+    && chown atlantis:atlantis /mnt/efs/ -R 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,5 +2,7 @@
 set -xev
 create_github_user_ssh_key.sh
 mount
+ls -la /mnt
+whoami
 set -- docker-entrypoint-original.sh "$@"
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/dumb-init /bin/sh
-set -e
+set -xev
 create_github_user_ssh_key.sh
 set -- docker-entrypoint-original.sh "$@"
 exec "$@"
+mount

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/dumb-init /bin/sh
 set -xev
 create_github_user_ssh_key.sh
+mount
 set -- docker-entrypoint-original.sh "$@"
 exec "$@"
-mount

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/dumb-init /bin/sh
-set -xev
+set -e
 create_github_user_ssh_key.sh
 chown atlantis.atlantis /mnt/efs -R
 set -- docker-entrypoint-original.sh "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 set -xev
 create_github_user_ssh_key.sh
 mount
+chown atlantis.atlantis /mnt/efs -R
 ls -la /mnt
 whoami
 set -- docker-entrypoint-original.sh "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,9 +1,6 @@
 #!/bin/dumb-init /bin/sh
 set -xev
 create_github_user_ssh_key.sh
-mount
 chown atlantis.atlantis /mnt/efs -R
-ls -la /mnt
-whoami
 set -- docker-entrypoint-original.sh "$@"
 exec "$@"


### PR DESCRIPTION
# Adding Folder and changing permissions in preparation for EFS

To be able to mount efs a folder under /mnt with the name efs(it can be any name but to make it easier to find and troubleshoot this name) then change the permissions to be owned by atlantis user as per even if the task its run as root within the base image its forced to be atlantis and the default permissions are assigned to root user.

