### PR TITLE
OPS-0 Add aws cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM runatlantis/atlantis:latest
 
-RUN apk add unzip make curl
+RUN apk add \
+	aws-cli \
+	curl \
+	make \
+	unzip
 
 # TODO: verify GPG
 ARG TERRAGRUNT_VERSION=0.21


### PR DESCRIPTION
# Add aws cli

Terraform does not support to assume another IAM role, so we will do that manually in Atlantis projects that use Terraform (not Terragrunt) with something similar to this:

```
aws_credentials=$(aws sts assume-role --role-arn arn:aws:iam::1234567890:role/nameOfMyrole --role-session-name "RoleSession1")

export AWS_ACCESS_KEY_ID=$(echo $aws_credentials|jq '.Credentials.AccessKeyId'|tr -d '"')
export AWS_SECRET_ACCESS_KEY=$(echo $aws_credentials|jq '.Credentials.SecretAccessKey'|tr -d '"')
export AWS_SESSION_TOKEN=$(echo $aws_credentials|jq '.Credentials.SessionToken'|tr -d '"')
```