### PR TITLE
Adds the Terragrunt Atlantis config generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,11 +59,11 @@ RUN set -eux \
 ###
 ADD https://github.com/transcend-io/terragrunt-atlantis-config/releases/download/v${TERRAGRUNT_ATLANTIS_CONFIG}/terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64.tar.gz /usr/local/bin/
 RUN set -eux \
-		&& cd /usr/local/bin \
-		&& tar xvzf terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64.tar.gz \
-		&& mv terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64/terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64 terragrunt-atlantis-config \
-		&& chmod +x terragrunt-atlantis-config \
-		&& rm -rf terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64*
+	&& cd /usr/local/bin \
+	&& tar xvzf terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64.tar.gz \
+	&& mv terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64/terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64 terragrunt-atlantis-config \
+	&& chmod +x terragrunt-atlantis-config \
+	&& rm -rf terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64*
 
 ###
 ### Flaconi customized entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apk add \
 
 ARG TERRAGRUNT
 ARG TERRAFORM
+ARG TERRAGRUNT_ATLANTIS_CONFIG
 
 ###
 ### Ensure Terraform version is present, linked and validated
@@ -52,6 +53,17 @@ RUN set -eux \
 	&& curl -L -sS "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT}/terragrunt_linux_amd64" -o /usr/local/bin/terragrunt \
 	&& chmod +x /usr/local/bin/terragrunt \
 	&& terragrunt --version | grep "v${TERRAGRUNT}"
+
+###
+### Ensure the Terragrunt Atlantis Config is present
+###
+ADD https://github.com/transcend-io/terragrunt-atlantis-config/releases/download/v${TERRAGRUNT_ATLANTIS_CONFIG}/terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64.tar.gz /usr/local/bin/
+RUN set -eux \
+		&& cd /usr/local/bin \
+		&& tar xvzf terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64.tar.gz \
+		&& mv terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64/terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64 terragrunt-atlantis-config \
+		&& chmod +x terragrunt-atlantis-config \
+		&& rm -rf terragrunt-atlantis-config_${TERRAGRUNT_ATLANTIS_CONFIG}_linux_amd64*
 
 ###
 ### Flaconi customized entrypoint

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ TAG = latest
 ATLANTIS = '0.17.4'
 TERRAFORM = '1.0.8'
 TERRAGRUNT = '0.34.1'
+TERRAGRUNT_ATLANTIS_CONFIG = '1.9.2'
 
 pull:
 	docker pull $(shell grep FROM Dockerfile | sed 's/^FROM//g' | sed "s/\$${ATLANTIS}/$(ATLANTIS)/g";)
@@ -22,12 +23,14 @@ build:
 		--build-arg ATLANTIS=$(ATLANTIS) \
 		--build-arg TERRAFORM=$(TERRAFORM) \
 		--build-arg TERRAGRUNT=$(TERRAGRUNT) \
+		--build-arg TERRAGRUNT_ATLANTIS_CONFIG=$(TERRAGRUNT_ATLANTIS_CONFIG) \
 		-t $(IMAGE) -f $(DIR)/$(FILE) $(DIR)
 
 test:
 	docker run --rm ${IMAGE} atlantis version | grep -E '$(ATLANTIS)$$'
 	docker run --rm ${IMAGE} terraform --version | grep -E 'v$(TERRAFORM)$$'
 	docker run --rm ${IMAGE} terragrunt --version | grep -E 'v$(TERRAGRUNT)$$'
+	docker run --rm ${IMAGE} terragrunt-atlantis-config version | grep -E "$(TERRAGRUNT_ATLANTIS_CONFIG)$$"
 
 tag:
 	docker tag $(IMAGE) $(IMAGE):$(TAG)

--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ For building you can overwrite your desired versions with the following three Ma
 * `ATLANTIS`
 * `TERRAFORM`
 * `TERRAGRUNT`
+* `TERRAGRUNT_ATLANTIS_CONFIG`
 
 ```
 make build
 make build TERRAFORM=1.0.8
 make build TERRAFORM=1.0.8 TERRAGRUNT=0.34.1
 make build TERRAFORM=1.0.8 TERRAGRUNT=0.34.1 ATLANTIS=0.17.4
+make build TERRAFORM=1.0.8 TERRAGRUNT=0.34.1 ATLANTIS=0.17.4 TERRAGRUNT_ATLANTIS_CONFIG=1.9.2
 ```
 
 ## Available images


### PR DESCRIPTION
In a desperate attempt to rid ourselves of them 14K lines worth of `atlantis.yaml` files, we want to give this neat utility a stab: https://github.com/transcend-io/terragrunt-atlantis-config